### PR TITLE
Minor update to support scribe changes

### DIFF
--- a/src/main/java/com/flickr/api/Flickr.java
+++ b/src/main/java/com/flickr/api/Flickr.java
@@ -88,6 +88,8 @@ public final class Flickr {
     
     public void setProxy(Proxy proxy)
     {
+        oauthHandler.setProxy(proxy);
+        
         contactsService.setProxy(proxy);
         peoplesService.setProxy(proxy);
         photosService.setProxy(proxy);

--- a/src/main/java/com/flickr/api/OAuthHandler.java
+++ b/src/main/java/com/flickr/api/OAuthHandler.java
@@ -21,6 +21,10 @@
  */
 package com.flickr.api;
 
+import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.URL;
+
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.exceptions.OAuthException;
 import org.scribe.model.OAuthRequest;
@@ -55,6 +59,11 @@ class OAuthHandler {
                 .callback(callbackUrl)
                 .build();
         load();
+    }
+    
+    public void setProxy(Proxy proxy)
+    {
+        service.setProxy(proxy);
     }
 
     private void load() {


### PR DESCRIPTION
I had overlooked the fact that scribe creates Request objects internally when fetching tokens.  These additional changes should ensure that those connections will also use the proxy, if one has been set.
